### PR TITLE
remove the header totals

### DIFF
--- a/src/media/css/stats.styl
+++ b/src/media/css/stats.styl
@@ -89,41 +89,6 @@ $dash-tile-width = 290px;
     }
 }
 
-.dashboard-controls {
-    background-color: #efefef;
-    height: 40px;
-    margin: 0 auto;
-    width: 100%;
-}
-
-.dashboard-summary-metrics {
-    background-repeat: repeat-x;
-    gradientLeft(unquote('rgba(49,48,48,1) 0%, rgba(64,64,64,1) 100%'));
-    height: 110px;
-    margin: 0 auto;
-    width: 100%;
-    .head {
-        border-bottom: 0;
-        border-top: 0;
-        color: white;
-        float: right;
-        font-size: 24px;
-        font-weight: 600;
-        height: 50px;
-        padding: 30px 0 4px 0;
-        text-align: center;
-        width: 170px;
-        .tiny {
-            font-size: 12px;
-            font-weight: 600;
-            margin-top: -2px;
-        }
-    }
-    .head-rightmost {
-         margin-right: 120px;
-    }
-}
-
 @-webkit-keyframes spin {
     from { -webkit-transform: rotate(0turn); }
     to { -webkit-transform: rotate(1turn); }
@@ -314,6 +279,7 @@ ul {
     box-shadow: 1px 1px 8px #a5a5a5;
     margin: 30px auto 50px auto;
     padding-bottom: 30px;
+    padding-top: 30px;
 }
 
 .sidebar {

--- a/src/templates/homepage.html
+++ b/src/templates/homepage.html
@@ -1,28 +1,5 @@
 <section class="main">
   <div class="page-container-app">
-    <div class="apps">
-      <div class="dashboard-summary-metrics">
-        <div class="head head-rightmost">
-          <div class="total-val installs"></div>
-          <div class="tiny">{{ _('App Installations') }}</div>
-        </div>
-        <div class="head">
-          <div id="developers">{{ _('N/A') }}</div>
-          <div class="tiny">{{ _('Developers') }}</div>
-        </div>
-        <div class="head">
-          <div id="transactions">{{ _('N/A') }}</div>
-          <div class="tiny">{{ _('Transactions') }}</div>
-        </div>
-        <div class="head">
-          <div id="revenue">{{ _('N/A') }}</div>
-          <div class="tiny">{{ _('Net payments') }} (<span class="currency">{{ _('USD') }}</span>)</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="dashboard-controls"></div>
-
     <ul class="dashboard c">
       <li>
         <a href="{{ url('total_developers') }}" data-src="total_developers">


### PR DESCRIPTION
before:
![screenshot 2014-12-29 10 36 36](https://cloud.githubusercontent.com/assets/74699/5571467/9677d4f2-8f46-11e4-9d25-52ba8fb856b7.png)
after:
![screenshot 2014-12-29 10 35 58](https://cloud.githubusercontent.com/assets/74699/5571460/807c0c2c-8f46-11e4-87f9-e9f2679981d1.png)

I'm pretty sure that we were meant to replace the N/A with something else, but it's been a while and we haven't got anything there. I removed the N/A's and then installations was the only one there and that seemed kinda empty. 

So I'm not sure if this is an improvement, but it remove's the N/A and whole top bar until we have the time come up with something else.

r? @spasovski 
